### PR TITLE
High memory usage with many items to analyze

### DIFF
--- a/src/main/java/com/cys4/sensitivediscoverer/component/LogsTable.java
+++ b/src/main/java/com/cys4/sensitivediscoverer/component/LogsTable.java
@@ -19,7 +19,6 @@ import java.util.List;
  */
 public class LogsTable extends JTable {
 
-    // get the reference of the array of entries
     private final List<LogEntity> logEntries;
     private final HttpRequestEditor requestViewer;
     private final HttpResponseEditor responseViewer;
@@ -42,7 +41,7 @@ public class LogsTable extends JTable {
         int realRow = this.convertRowIndexToModel(row);
         LogEntity logEntry = logEntries.get(realRow);
 
-        updateRequestViewers(logEntry.getRequestResponse().finalRequest(), logEntry.getRequestResponse().response(), logEntry.getMatch());
+        updateRequestViewers(logEntry.getRequest(), logEntry.getResponse(), logEntry.getMatch());
     }
 
     public void updateRequestViewers(HttpRequest request, HttpResponse response, String search) {

--- a/src/main/java/com/cys4/sensitivediscoverer/component/LogsTableContextMenu.java
+++ b/src/main/java/com/cys4/sensitivediscoverer/component/LogsTableContextMenu.java
@@ -10,7 +10,6 @@ import burp.api.montoya.core.ByteArray;
 import burp.api.montoya.http.message.HttpRequestResponse;
 import burp.api.montoya.http.message.requests.HttpRequest;
 import burp.api.montoya.http.message.responses.HttpResponse;
-import burp.api.montoya.proxy.ProxyHttpRequestResponse;
 import burp.api.montoya.ui.editor.HttpRequestEditor;
 import burp.api.montoya.ui.editor.HttpResponseEditor;
 import com.cys4.sensitivediscoverer.model.LogEntity;
@@ -37,13 +36,15 @@ public class LogsTableContextMenu extends JPopupMenu {
                                 MontoyaApi burpApi,
                                 boolean isAnalysisRunning) {
         RegexEntity regexEntity = logEntry.getRegexEntity();
-        ProxyHttpRequestResponse requestResponse = logEntry.getRequestResponse();
+        String url = logEntry.getRequestUrl();
+        HttpRequest request = logEntry.getRequest();
+        HttpResponse response = logEntry.getResponse();
         Clipboard systemClipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
 
         JMenuItem sendToRepeater = new JMenuItem(new AbstractAction(getLocaleString("logger-ctxMenu-sendToRepeater")) {
             @Override
             public void actionPerformed(ActionEvent e) {
-                burpApi.repeater().sendToRepeater(requestResponse.finalRequest(), regexEntity.getDescription());
+                burpApi.repeater().sendToRepeater(request, regexEntity.getDescription());
             }
         });
         this.add(sendToRepeater);
@@ -51,7 +52,7 @@ public class LogsTableContextMenu extends JPopupMenu {
         JMenuItem sendToIntruder = new JMenuItem(new AbstractAction(getLocaleString("logger-ctxMenu-sendToIntruder")) {
             @Override
             public void actionPerformed(ActionEvent e) {
-                burpApi.intruder().sendToIntruder(requestResponse.finalRequest());
+                burpApi.intruder().sendToIntruder(request);
             }
         });
         this.add(sendToIntruder);
@@ -59,10 +60,11 @@ public class LogsTableContextMenu extends JPopupMenu {
         JMenuItem sendToOrganizer = new JMenuItem(new AbstractAction(getLocaleString("logger-ctxMenu-sendToOrganizer")) {
             @Override
             public void actionPerformed(ActionEvent e) {
-                burpApi.organizer().sendToOrganizer(HttpRequestResponse.httpRequestResponse(
-                        requestResponse.finalRequest(),
-                        requestResponse.response(),
-                        Annotations.annotations(logEntry.getMatch())));
+                burpApi.organizer().sendToOrganizer(
+                        HttpRequestResponse.httpRequestResponse(
+                                request,
+                                response,
+                                Annotations.annotations(logEntry.getMatch())));
             }
         });
         this.add(sendToOrganizer);
@@ -71,13 +73,13 @@ public class LogsTableContextMenu extends JPopupMenu {
         JMenuItem comparerRequest = new JMenuItem(new AbstractAction(getLocaleString("common-request")) {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
-                burpApi.comparer().sendToComparer(requestResponse.finalRequest().toByteArray());
+                burpApi.comparer().sendToComparer(request.toByteArray());
             }
         });
         JMenuItem comparerResponse = new JMenuItem(new AbstractAction(getLocaleString("common-response")) {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
-                burpApi.comparer().sendToComparer(requestResponse.response().toByteArray());
+                burpApi.comparer().sendToComparer(response.toByteArray());
             }
         });
         sendToComparer.add(comparerRequest);
@@ -113,7 +115,7 @@ public class LogsTableContextMenu extends JPopupMenu {
         this.add(new JMenuItem(new AbstractAction(getLocaleString("logger-ctxMenu-copyURL")) {
             @Override
             public void actionPerformed(final ActionEvent e) {
-                StringSelection selection = new StringSelection(requestResponse.finalRequest().url());
+                StringSelection selection = new StringSelection(url);
                 systemClipboard.setContents(selection, selection);
             }
         }));

--- a/src/main/java/com/cys4/sensitivediscoverer/model/LogsTableModel.java
+++ b/src/main/java/com/cys4/sensitivediscoverer/model/LogsTableModel.java
@@ -57,7 +57,7 @@ public class LogsTableModel extends AbstractTableModel {
         LogEntity logEntity = logEntries.get(rowIndex);
 
         return switch (columnIndex) {
-            case 0 -> logEntity.getRequestResponse().finalRequest().url();
+            case 0 -> logEntity.getRequestUrl();
             case 1 -> logEntity.getRegexEntity().getDescription() + " - " + logEntity.getRegexEntity().getRegex();
             case 2 -> logEntity.getMatch();
             default -> "";

--- a/src/test/java/com/cys4/sensitivediscoverer/mock/ByteArrayMock.java
+++ b/src/test/java/com/cys4/sensitivediscoverer/mock/ByteArrayMock.java
@@ -1,0 +1,182 @@
+package com.cys4.sensitivediscoverer.mock;
+
+import burp.api.montoya.core.ByteArray;
+import burp.api.montoya.core.Range;
+import org.apache.commons.lang3.NotImplementedException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.regex.Pattern;
+
+public class ByteArrayMock implements ByteArray {
+    private final String data;
+
+    public ByteArrayMock(String data) {
+        this.data = data;
+    }
+
+    @Override
+    public byte[] getBytes() {
+        return data.getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public byte getByte(int i) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void setByte(int i, byte b) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void setByte(int i, int i1) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void setBytes(int i, byte... bytes) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void setBytes(int i, int... ints) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void setBytes(int i, ByteArray byteArray) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public int length() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public ByteArray subArray(int i, int i1) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public ByteArray subArray(Range range) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public ByteArray copy() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public ByteArray copyToTempFile() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public int indexOf(ByteArray byteArray) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public int indexOf(String s) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public int indexOf(ByteArray byteArray, boolean b) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public int indexOf(String s, boolean b) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public int indexOf(ByteArray byteArray, boolean b, int i, int i1) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public int indexOf(String s, boolean b, int i, int i1) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public int indexOf(Pattern pattern) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public int indexOf(Pattern pattern, int i, int i1) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public int countMatches(ByteArray byteArray) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public int countMatches(String s) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public int countMatches(ByteArray byteArray, boolean b) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public int countMatches(String s, boolean b) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public int countMatches(ByteArray byteArray, boolean b, int i, int i1) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public int countMatches(String s, boolean b, int i, int i1) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public int countMatches(Pattern pattern) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public int countMatches(Pattern pattern, int i, int i1) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public ByteArray withAppended(byte... bytes) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public ByteArray withAppended(int... ints) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public ByteArray withAppended(String s) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public ByteArray withAppended(ByteArray byteArray) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public Iterator<Byte> iterator() {
+        throw new NotImplementedException();
+    }
+}

--- a/src/test/java/com/cys4/sensitivediscoverer/mock/HttpRequestMock.java
+++ b/src/test/java/com/cys4/sensitivediscoverer/mock/HttpRequestMock.java
@@ -42,7 +42,12 @@ public class HttpRequestMock implements HttpRequest {
 
     @Override
     public String bodyToString() {
-        return body;
+        return this.body;
+    }
+
+    @Override
+    public ByteArray body() {
+        return new ByteArrayMock(this.body);
     }
 
     @Override
@@ -157,11 +162,6 @@ public class HttpRequestMock implements HttpRequest {
 
     @Override
     public int bodyOffset() {
-        throw new NotImplementedException();
-    }
-
-    @Override
-    public ByteArray body() {
         throw new NotImplementedException();
     }
 

--- a/src/test/java/com/cys4/sensitivediscoverer/mock/HttpResponseMock.java
+++ b/src/test/java/com/cys4/sensitivediscoverer/mock/HttpResponseMock.java
@@ -39,6 +39,11 @@ public class HttpResponseMock implements HttpResponse {
     }
 
     @Override
+    public ByteArray body() {
+        return new ByteArrayMock(this.body);
+    }
+
+    @Override
     public short statusCode() {
         throw new NotImplementedException();
     }
@@ -135,11 +140,6 @@ public class HttpResponseMock implements HttpResponse {
 
     @Override
     public int bodyOffset() {
-        throw new NotImplementedException();
-    }
-
-    @Override
-    public ByteArray body() {
         throw new NotImplementedException();
     }
 


### PR DESCRIPTION
The main analysis method kept the list of all the requests/requests to analyze in memory until the analysis was finished. When many requests are analyzed, the memory used only increases, resulting in an OutOfMemory exception if the reserved memory isn't big enough.

This was more noticeable with the recent switch to the newer APIs, which now deeply duplicate all requests/responses, resulting in an overall higher memory usage.

Solving the problem requires removing references to already analyzed requests. The GC will then be able to pick up the objects when needed.